### PR TITLE
Correct indentation in ArrayCreds schema description

### DIFF
--- a/deploy/00crds.yaml
+++ b/deploy/00crds.yaml
@@ -43,7 +43,7 @@ spec:
       openAPIV3Schema:
         description: |-
           ArrayCreds is the Schema for the storage array credentials API that defines authentication
-          and connection details for storage arrays. It provides a secure way to store and validate
+          and connection  details for storage arrays. It provides a secure way to store and validate
           storage array credentials for use in migration operations, supporting multiple vendors, but as of now
           We have qualified pure storage flash array.
         properties:


### PR DESCRIPTION
Fix indentation in the description of ArrayCreds schema.

## What this PR does / why we need it


## Which issue(s) this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*

fixes #

## Special notes for your reviewer


## Testing done

_please add testing details (logs, screenshots, etc.)_